### PR TITLE
Fix critical installation bugs and modernize for current Kali Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Table of Contents
 * [Pi-PwnBox-RogueAP](#pi-pwnbox-rogueap)
 * [Equipment used](#equipment-used)
 * [WiFi USB Adapters Overview](#wifi-usb-adapters-overview)
+* [Requirements & Compatibility](#requirements--compatibility)
 * [Installation](#installation)
 * [PwnBox Network Configuration](#pwnbox-network-configuration)
   * [Wireless Dedicated Administration Network](#wireless-dedicated-administration-network)
@@ -31,6 +32,7 @@ Table of Contents
 * [PwnBox Remote Access](#pwnbox-remote-access)
 * [Usage](#usage)
 * [WiFi Hacking Cheatsheets &amp; Mind Map](#wifi-hacking-cheatsheets--mind-map)
+* [Troubleshooting](#troubleshooting)
 * [Possible Upgrade](#possible-upgrade)
 
   
@@ -38,15 +40,15 @@ Table of Contents
 Equipment used
 --------------
 
-- [Raspberry Pi 3 Model B+](https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus)
-- Micro SD Memory Card 64 Go
-- Raspberry Pi Case
+- [Raspberry Pi 3 Model B+](https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus), [Pi 4](https://www.raspberrypi.org/products/raspberry-pi-4-model-b) or [Pi 5](https://www.raspberrypi.org/products/raspberry-pi-5)
+- Micro SD Memory Card 64 GB (class 10 or better, UHS-I recommended)
+- Raspberry Pi Case (with passive/active cooling for Pi 4/5)
 - Alfa WiFi USB Adapter [AWUS036NEH](https://www.alfa.com.tw/products_detail/10.htm)
 - Alfa WiFi USB Adapter [AWUS036ACH](https://www.alfa.com.tw/products_detail/1.htm)
 - BrosTrend WiFi USB Adapter AC1L AC1200 (can be replaced by any adapter supporting AP mode)
 - USB cable Male to Female
 - Rii Mini Wireless Keyboard (optional)
-- Powerbank
+- Powerbank (minimum 2.5A for Pi 3, 3A+ for Pi 4/5)
 
 
 
@@ -64,36 +66,46 @@ WiFi USB Adapters Overview
 
 
 
+Requirements & Compatibility
+------------------------------
+
+- **OS:** [Kali Linux ARM](https://www.kali.org/get-kali/#kali-arm) for Raspberry Pi (64-bit recommended for Pi 4/5).
+- **Internet:** During installation the PwnBox must have access to the Internet.
+- **Root:** Install script must be run as `root`.
+- **Note for Pi 4/5:** The 64-bit Kali ARM image is highly recommended. All tools work on `arm64`, but some older precompiled binaries may require `box64` or manual compilation.
+
+
+
 Installation
 ------------
 
-1. Download Kali Linux ARM Image for Raspberry Pi: https://www.offensive-security.com/kali-linux-arm-images/
-2. Flash Kali Linux ARM Image for Rapberry Pi onto Micro SD Card.
-3. Make sure to have Internet connection on PwnBox.
+1. Download Kali Linux ARM Image for Raspberry Pi: https://www.kali.org/get-kali/#kali-arm
+2. Flash Kali Linux ARM Image for Raspberry Pi onto Micro SD Card (use [Raspberry Pi Imager](https://www.raspberrypi.com/software/) or `dd`).
+3. Boot Raspberry Pi, log in (default kali/kali) and make sure it has Internet connection.
 4. Download install scripts/configurations on the PwnBox:
-   ```
+   ```bash
    git clone https://github.com/koutto/pi-pwnbox-rogueap.git
    ```
-5. **Important:** Edit install script configuration at the top of `scripts/install-system.sh`file:
+5. **Important:** Edit install script configuration at the top of `scripts/install-system.sh` file:
 
-   - Choose *Guacamole* passwords.
+   - Choose *Guacamole* passwords (`GUACAMOLE_PASSWORD`, `GUACAMOLE_MYSQL_PASSWORD`).
    - Set WiFi interfaces persistent names based on their MAC addresses: `wlxaabbccddeeff` for a device with MAC address `aa:bb:cc:dd:ee:ff`.
    - Set MAC addresses of `eth0` & `wlan0` (built-in interfaces).
-   - Set WiFi connection settings.
+   - Set WiFi connection settings (`WIFI_SSID`, `WIFI_PASSPHRASE`).
 6. Run install script (will pause at the end of each step in order to allow for manual inspection of command outputs)
-   ```
+   ```bash
    cd pi-pwnbox-rogueap/scripts
    ./install-system.sh
    ```
 7. Reboot & check correct configuration of network interfaces:
 
-   ```
+   ```bash
    ip a
    iwconfig
    ```
    - Built-in wired and wireless interfaces should be named `eth0` and `wlan0` respectively.
-   - WiFi USB Adapters should use persistent naming (modern naming convention).
-   - AP (`PWNBOX_ADMIN`) should be started on appropriate `wlx*`interface.
+   - WiFi USB Adapters should use persistent naming (modern naming convention `wlx*`).
+   - AP (`PWNBOX_ADMIN`) should be started on appropriate `wlx*` interface.
 8. Configure VNC-over-HTTP on *Guacamole*:
    1. Connect to Guacamole at http://<ip_pwnbox>:8080/guacamole/
    2. Go to *guacadmin (top right) > Settings > Connections*
@@ -111,7 +123,7 @@ Installation
       - Authentication Password = `(password chosen at install when running install-system.sh)`
       - Color depth = `True color (32-bit)`
 9. Change default credentials:
-   - Kali system credentials
+   - Kali system credentials (`passwd kali`)
    - Guacamole credentials (via `http://<ip_pwnbox>:8080/guacamole/#/manage/mysql/users/guacadmin`)
 
 
@@ -138,11 +150,11 @@ When booting, PwnBox automatically connects to:
      - Use wired network,
      - Use monitor + (wireless) keyboard.
   2. Add WPA passphrase to PwnBox local configuration:
-     ```
+     ```bash
      wpa_passphrase <SSID> <passphrase> >> /etc/wpa_supplicant.conf
      ```
   3. Test connection:
-     ```
+     ```bash
      wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant.conf
      dhclient -v wlan0
      ping 8.8.8.8
@@ -155,20 +167,20 @@ PwnBox can be controlled through:
 
 - **SSH Service (22/tcp):**
 
-  ```
+  ```bash
   ssh kali@<ip_pwnbox>
   ```
 
 - **VNC-over-HTTP with Guacamole (8080/tcp):** 
 
-  ```
+  ```bash
   http://<ip_pwnbox>:8080/guacamole
   ```
 
 **PwnBox's IP** depends on the network you want to access it from:
 
 - Via Wireless Dedicated Administration Network (i.e. connected to hidden SSID `PWNBOX_ADMIN`): IP is always `10.0.0.1`.
-- Via LAN Network (wireless or wired): IP depends on the value allocated by DHCP server. IP can be found using `netdiscover`for example.
+- Via LAN Network (wireless or wired): IP depends on the value allocated by DHCP server. IP can be found using `netdiscover` for example.
 
 *Note: Guacamole service might take a lot of resources (RAM) when running. If not used, it can be stopped using `stop-guacamole.sh` script.*
 
@@ -197,7 +209,76 @@ WiFi Hacking Cheatsheets & Mind Map
 
 
 
+Troubleshooting
+---------------
+
+### Slow boot when Ethernet cable is unplugged
+Because `/etc/network/interfaces` uses `auto eth0`, the system waits for a DHCP lease during boot. If you frequently run the PwnBox without Ethernet and experience slow boots, edit `/etc/network/interfaces` and change:
+```bash
+auto eth0
+allow-hotplug eth0
+```
+to:
+```bash
+allow-hotplug eth0
+```
+(Remove the `auto eth0` line.)
+
+### DHCP service conflict warning
+`isc-dhcp-server` is installed because some tools (e.g., Fluxion) require it, but it is **disabled by default** to avoid a port 67/udp conflict with `dnsmasq` (which serves the `PWNBOX_ADMIN` AP). If you need `isc-dhcp-server`, stop `dnsmasq` first:
+```bash
+systemctl stop dnsmasq
+systemctl start isc-dhcp-server
+```
+
+### Guacamole / Tomcat service fails to start
+Newer Kali/Debian releases ship **Tomcat 10** instead of Tomcat 9. The `start-guacamole.sh` and `stop-guacamole.sh` scripts auto-detect the installed Tomcat version. If Guacamole does not work after install, check:
+```bash
+systemctl list-unit-files | grep tomcat
+systemctl status guacd
+systemctl status mysql
+# Then start manually with correct tomcat version, e.g.:
+systemctl start tomcat10
+```
+
+### BrosTrend AC1L driver issues
+If the vendor installer (`deb.trendtechcn.com`) is offline, build the driver manually:
+```bash
+sudo apt-get install -y bc git build-essential dkms
+sudo git clone https://github.com/cilynx/rtl88x2bu.git /usr/src/rtl88x2bu-5.8.7
+sudo dkms add -m rtl88x2bu -v 5.8.7
+sudo dkms autoinstall
+```
+
+### VNC server does not start
+Make sure you ran `vncpasswd` during install to create the password file:
+```bash
+vncpasswd
+systemctl restart vncserver
+```
+
+### Python 2 tools no longer work
+Python 2 has been removed from modern Kali. The install script now uses **Python 3 only**. If you have old custom Python 2 tools, migrate them to Python 3 or run them in a dedicated Docker container.
+
+### No Internet after disabling NetworkManager
+The install script disables NetworkManager in favor of classic `/etc/network/interfaces`. If you need to temporarily re-enable NM:
+```bash
+systemctl start NetworkManager
+systemctl enable NetworkManager
+```
+
+### Wireless interface names changed after reboot
+Check that your MAC addresses in `install-system.sh` match reality:
+```bash
+ip link show
+```
+Then re-run the network configuration section or update `/etc/udev/rules.d/70-persistent-net.rules` manually.
+
+
+
 Possible Upgrade
 ----------------
 
 - Add 4G USB dongle for remote access to PwnBox using 4G cell network.
+- Replace BrosTrend AC1L with a dual-band AP-capable adapter supporting 802.11ax (WiFi 6) for better performance.
+- Add GPS USB module for wardriving with Kismet.

--- a/scripts/config/vncserver.service
+++ b/scripts/config/vncserver.service
@@ -3,12 +3,11 @@ Description=VNC remote desktop server
 After=sshd.service
 
 [Service]
-Type=dbus
-ExecStart=/usr/bin/vncserver -localhost no
+Type=forking
+ExecStart=/usr/bin/vncserver :1 -localhost no
 Restart=on-failure
 RestartSec=3
 User=root
-Type=forking
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install-system.sh
+++ b/scripts/install-system.sh
@@ -71,8 +71,8 @@ read -n 1 -s -r -p "Press any key to continue"
 
 echo "${YELLOW}[~] Add Kali rolling repository in /etc/apt/sources.list${RESET}"
 # https://www.kali.org/docs/general-use/kali-linux-sources-list-repositories/
-if cat /etc/apt/sources.list | grep -q "deb http://http.kali.org/kali kali-rolling main non-free contrib"; then
-	echo "deb http://http.kali.org/kali kali-rolling main non-free contrib" | tee /etc/apt/sources.list
+if ! grep -q "deb http://http.kali.org/kali kali-rolling main non-free contrib" /etc/apt/sources.list; then
+	echo "deb http://http.kali.org/kali kali-rolling main non-free contrib" | tee -a /etc/apt/sources.list
 fi
 read -n 1 -s -r -p "Press any key to continue"
 
@@ -86,35 +86,38 @@ read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install additional utils & dependencies ...${RESET}"
-apt-get -y install htop iotop bashtop bmon git libcurl4-openssl-dev libssl-dev zlib1g-dev libpcap-dev
-apt-get -y install dhcpd php-cgi iftop build-essential pkg-config libnl-genl-3-dev
-apt-get -y install python3-pip python3-scapy
+apt-get -y install htop iotop btop bmon git libcurl4-openssl-dev libssl-dev zlib1g-dev libpcap-dev
+apt-get -y install isc-dhcp-server php-cgi iftop build-essential pkg-config libnl-genl-3-dev
+apt-get -y install python3-pip python3-scapy netdiscover plocate
 read -n 1 -s -r -p "Press any key to continue"
 
 
-echo "${YELLOW}[~] Update datetime...${RESET}"
-apt-get install -y ntp ntpdate
-ntpdate fr.pool.ntp.org
-date
-cp config/ntpdate.service /etc/systemd/system/ntpdate.service
-chown root:root /etc/systemd/system/ntpdate.service
-chmod 644 /etc/systemd/system/ntpdate.service
-systemctl enable ntpdate
-systemctl start ntpdate
+echo "${YELLOW}[~] Update datetime using systemd-timesyncd...${RESET}"
+apt-get install -y systemd-timesyncd
+systemctl enable systemd-timesyncd
+systemctl start systemd-timesyncd
+timedatectl status
+read -n 1 -s -r -p "Press any key to continue"
 
 
 # -------------------------------------------------------------------------------------------------
-# WiFi Driver for Device not working out-ot-box on Kali
+# WiFi Driver for Device not working out-of-box on Kali
 
 echo "${YELLOW}[~] Install Wi-Fi drivers for Realtek RTL88x2bu (BrosTrend AC1200 Model AC1L Dongle)...${RESET}"
 # https://fr.scribd.com/document/424931230/AC1L-AC3L-Linux-Manual-BrosTrend-WiFI-Adapter-v4
-wget deb.trendtechcn.com/installer.sh -O /tmp/installer.sh
-chmod +x /tmp/installer.sh
-sudo /tmp/installer.sh
+# Fallback: if vendor script fails, manual build instructions are in README
+wget --timeout=30 -q deb.trendtechcn.com/installer.sh -O /tmp/installer.sh
+if [ -s /tmp/installer.sh ]; then
+	chmod +x /tmp/installer.sh
+	sudo /tmp/installer.sh
+else
+	echo "${RED}[!] Vendor installer download failed. You may need to build the driver manually:${RESET}"
+	echo "    git clone https://github.com/cilynx/rtl88x2bu.git && cd rtl88x2bu && ./dkms-install.sh"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 echo "${YELLOW}[~] Check Wi-Fi Dongle Realtek RTL88x2bu correct install${RESET}"
-dmesg | grep -i rtl88
+dmesg | grep -i rtl88 || true
 lsusb
 iw dev
 ip a
@@ -128,8 +131,8 @@ echo "${YELLOW}[~] Enable SSH server...${RESET}"
 apt-get install -y ssh openssh-server
 systemctl enable ssh
 service ssh start
-systemctl status ssh
-netstat -latupen | grep ':22'
+systemctl status ssh || true
+ss -tulpen | grep ':22'
 read -n 1 -s -r -p "Press any key to continue"
 
 
@@ -143,36 +146,35 @@ read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Checking Guacamole status${RESET}"
-systemctl status tomcat9 guacd mysql
-netstat -latupen | grep "mysqld\|guacd\|java"
+TOMCAT_SVC=$(systemctl list-unit-files --type=service 2>/dev/null | grep -oE '^tomcat[0-9]*\.service' | head -n1 | sed 's/\.service//')
+[ -z "$TOMCAT_SVC" ] && TOMCAT_SVC="tomcat9"
+systemctl status ${TOMCAT_SVC} guacd mysql || true
+ss -tulpen | grep -E "mysqld|guacd|java"
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install and enable VNC service (autostart at boot)...${RESET}"
 apt-get install -y tigervnc-common tigervnc-standalone-server
 apt-get install -y autocutsel
-#mkdir ~/.vnc/ && wget https://gitlab.com/kalilinux/nethunter/build-scripts/kali-nethunter-project/-/raw/master/nethunter-fs/profiles/xstartup -O ~/.vnc/xstartup
-#apt-get install x11vnc
 rm -f /tmp/.X11-unix/X0
 rm -f /tmp/.X0-lock
-#vncserver -kill :1
-#vncserver :1
-#x11vnc -display :0 -autoport -localhost -nopw -bg -xkb -ncache -ncache_cr -quiet -forever
-#cp x11vnc.service /lib/systemd/system/x11vnc.service
-#systemctl enable x11vnc.service
 echo "${YELLOW}Enter VNC password to use:${RESET}"
 vncpasswd # Will ask for VNC password
+if [ ! -f /root/.vnc/passwd ]; then
+    echo "${RED}[!] VNC password file not found. Did you set the password? Aborting.${RESET}"
+    exit 1
+fi
 cp config/vncserver.service /etc/systemd/system/vncserver.service
 chown root:root /etc/systemd/system/vncserver.service
 chmod 644 /etc/systemd/system/vncserver.service
 systemctl start vncserver
 systemctl enable vncserver
-systemctl status vncserver
+systemctl status vncserver || true
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Check VNC server is running...${RESET}"
-netstat -latupen | grep -i vnc
+ss -tulpen | grep -i vnc
 read -n 1 -s -r -p "Press any key to continue"
 
 
@@ -180,17 +182,17 @@ read -n 1 -s -r -p "Press any key to continue"
 # System settings
 
 echo "${YELLOW}Configure auto-login at boot...${RESET}"
-mv /etc/lightdm/lightdm.conf /etc/lightdm/lightdm.conf.old
+[ -f /etc/lightdm/lightdm.conf ] && cp /etc/lightdm/lightdm.conf /etc/lightdm/lightdm.conf.backup.$(date +%Y%m%d%H%M%S)
 cp config/lightdm.conf /etc/lightdm/lightdm.conf
-mv /etc/pam.d/lightdm-autologin /etc/pam.d/lightdm-autologin.old
+[ -f /etc/pam.d/lightdm-autologin ] && cp /etc/pam.d/lightdm-autologin /etc/pam.d/lightdm-autologin.backup.$(date +%Y%m%d%H%M%S)
 cp config/lightdm-autologin /etc/pam.d/lightdm-autologin
 echo
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Disable Network-Manager to avoid undesirable side-effects...${RESET}"
-systemctl stop NetworkManager
-systemctl disable NetworkManager
+systemctl stop NetworkManager || true
+systemctl disable NetworkManager || true
 read -n 1 -s -r -p "Press any key to continue"
 
 
@@ -206,15 +208,14 @@ echo "${YELLOW}${WLAN_INTERFACE_ALFA_AWUS036ACH} => USB Adapter Alfa AWUS036ACH 
 # Note: We do not use wlan1, wlan2... naming for USB dongles devices because Udev feature appeared bugged
 # during tests (https://wiki.debian.org/NetworkInterfaceNames) and we need consistent naming to avoid confusion
 echo
-cp /usr/lib/systemd/network/73-usb-net-by-mac.link /usr/lib/systemd/network/73-usb-net-by-mac.link.old
-cp /usr/lib/systemd/network/99-default.link /usr/lib/systemd/network/99-default.link.old
+cp /usr/lib/systemd/network/73-usb-net-by-mac.link /usr/lib/systemd/network/73-usb-net-by-mac.link.old || true
+cp /usr/lib/systemd/network/99-default.link /usr/lib/systemd/network/99-default.link.old || true
 if [ -f /etc/udev/rules.d/70-persistent-net.rules ]; then
 	mv /etc/udev/rules.d/70-persistent-net.rules /etc/udev/rules.d/70-persistent-net.rules.old
 fi
 if [ -f /etc/udev/rules.d/73-usb-net-by-mac.rules ]; then
 	mv /etc/udev/rules.d/73-usb-net-by-mac.rules /etc/udev/rules.d/73-usb-net-by-mac.rules.old
 fi
-# cp config/70-persistent-net.rules /etc/udev/rules.d/70-persistent-net.rules
 cat > /etc/udev/rules.d/70-persistent-net.rules <<EOF
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="${MAC_ETH0}", NAME="eth0"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="${MAC_WLAN0}", NAME="wlan0"
@@ -223,17 +224,19 @@ EOF
 cp config/73-usb-net-by-mac.rules /etc/udev/rules.d/73-usb-net-by-mac.rules
 
 systemctl restart systemd-udevd
+udevadm control --reload-rules
+udevadm trigger --subsystem-match=net
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Configure network interfaces${RESET}"
-mv /etc/network/interfaces /etc/network/interfaces.old
+[ -f /etc/network/interfaces ] && cp /etc/network/interfaces /etc/network/interfaces.backup.$(date +%Y%m%d%H%M%S)
 cat > /etc/network/interfaces <<EOF
 
 auto lo
 iface lo inet loopback
 
-# Automatic connection to network via eth0 if Ethenet connected
+# Automatic connection to network via eth0 if Ethernet connected
 auto eth0
 allow-hotplug eth0
 iface eth0 inet dhcp
@@ -254,19 +257,15 @@ iface ${WLAN_INTERFACE_BROSTREND_AC1L} inet static
   address 10.0.0.1
   netmask 255.255.255.0
   up route add -net 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1
-# iface ${WLAN_INTERFACE_BROSTREND_AC1L} inet manual
-# ifdown ${WLAN_INTERFACE_BROSTREND_AC1L}
 
 
 # WiFi USB Adapter Alfa AWUS036NEH Ralink RT2870/RT3070
 # Disabled by default at boot
 iface ${WLAN_INTERFACE_ALFA_AWUS036NEH} inet manual
-ifdown ${WLAN_INTERFACE_ALFA_AWUS036NEH}
 
 # WiFi USB Adapter Alfa AWUS036ACH Realtek RTL8812AU
 # Disabled by default at boot
 iface ${WLAN_INTERFACE_ALFA_AWUS036ACH} inet manual
-ifdown ${WLAN_INTERFACE_ALFA_AWUS036ACH}
 
 EOF
 
@@ -283,7 +282,7 @@ read -n 1 -s -r -p "Press any key to continue"
 echo "${YELLOW}[~] Setup AP at boot for pwnbox access via WiFi...${RESET}"
 
 echo "${YELLOW}[~] Configure dnsmasq...${RESET}"
-mv /etc/dnsmasq.conf /etc/dnsmasq.conf.old
+[ -f /etc/dnsmasq.conf ] && cp /etc/dnsmasq.conf /etc/dnsmasq.conf.backup.$(date +%Y%m%d%H%M%S)
 cat > /etc/dnsmasq.conf <<EOF
 
 interface=${WLAN_INTERFACE_BROSTREND_AC1L}
@@ -301,7 +300,8 @@ EOF
 
 
 echo "${YELLOW}[~] Configure hostapd...${RESET}"
-mv /etc/hostapd/hostapd.conf /etc/hostapd.conf.old
+mkdir -p /etc/hostapd
+[ -f /etc/hostapd/hostapd.conf ] && cp /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.conf.backup.$(date +%Y%m%d%H%M%S)
 cat > /etc/hostapd/hostapd.conf <<EOF
 
 interface=${WLAN_INTERFACE_BROSTREND_AC1L}
@@ -323,12 +323,23 @@ wme_enabled=1
 EOF
 
 echo "${YELLOW}[~] Configure hostapd & dnsmasq to start at boot as service...${RESET}"
-systemctl unmask hostapd # by default, service is masked on pi
+# Tell hostapd where its config file is
+if [ -f /etc/default/hostapd ]; then
+    if grep -q '^DAEMON_CONF=' /etc/default/hostapd; then
+        sed -i 's|^DAEMON_CONF=.*|DAEMON_CONF="/etc/hostapd/hostapd.conf"|' /etc/default/hostapd
+    else
+        echo 'DAEMON_CONF="/etc/hostapd/hostapd.conf"' >> /etc/default/hostapd
+    fi
+fi
+systemctl unmask hostapd || true # by default, service is masked on pi
 systemctl enable hostapd
 systemctl start hostapd
 
 systemctl enable dnsmasq
 systemctl start dnsmasq
+# Disable isc-dhcp-server to avoid port 67/udp conflict with dnsmasq
+systemctl disable isc-dhcp-server || true
+systemctl stop isc-dhcp-server || true
 
 read -n 1 -s -r -p "Press any key to continue"
 
@@ -357,104 +368,107 @@ read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install beef-xss from repository (if not already)...${RESET}"
-apt-get install -y beef-xss
-read -n 1 -s -r -p "Press any key to continue"
-
-
-echo "${YELLOW}[~] Install pip2 for old python2.7 scripts dependencies install...${RESET}"
-cd /tmp
-curl -k https://bootstrap.pypa.io/get-pip.py --output get-pip.py
-python2 get-pip.py
-read -n 1 -s -r -p "Press any key to continue"
-
-
-echo "${YELLOW}[~] Install Scapy & Scapy-com for Python2...${RESET}"
-python2 -m pip install scapy
-cd /usr/share
-git clone https://github.com/Tylous/Scapy-com.git
-cd Scapy-com
-python2 setup.py install
+apt-get install -y beef-xss || echo "${YELLOW}[~] beef-xss may not be available on this architecture, skipping${RESET}"
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install Wifipumpkin3...${RESET}"
-apt-get install -y libssl-dev libffi-dev build-essential
-cd /usr/share
-git clone https://github.com/P0cL4bs/wifipumpkin3.git
-cd wifipumpkin3
-apt-get install -y python3-pyqt5
-python3 setup.py install
-python3 -m pip install pyOpenSSL==19.0.0
+apt-get install -y libssl-dev libffi-dev build-essential python3-pyqt5
+if [ -d /usr/share/wifipumpkin3 ]; then
+	echo "${YELLOW}[~] Updating existing Wifipumpkin3...${RESET}"
+	cd /usr/share/wifipumpkin3 && git pull
+else
+	cd /usr/share && git clone https://github.com/P0cL4bs/wifipumpkin3.git
+fi
+cd /usr/share/wifipumpkin3
+python3 -m pip install . --break-system-packages 2>/dev/null || python3 -m pip install .
+python3 -m pip install pyOpenSSL --break-system-packages 2>/dev/null || python3 -m pip install pyOpenSSL
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install Wifiphisher...${RESET}"
-cd /usr/share
-git clone https://github.com/wifiphisher/wifiphisher.git
-cd wifiphisher
+if [ -d /usr/share/wifiphisher ]; then
+	cd /usr/share/wifiphisher && git pull
+else
+	cd /usr/share && git clone https://github.com/wifiphisher/wifiphisher.git
+fi
+cd /usr/share/wifiphisher
 apt-get install -y libnl-3-dev libnl-genl-3-dev
-python3 setup.py install
+python3 -m pip install . --break-system-packages 2>/dev/null || python3 -m pip install .
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install Fluxion...${RESET}"
-cd /usr/share
-git clone https://github.com/FluxionNetwork/fluxion.git
+if [ -d /usr/share/fluxion ]; then
+	cd /usr/share/fluxion && git pull
+else
+	cd /usr/share && git clone https://github.com/FluxionNetwork/fluxion.git
+fi
 # Fluxion requires X (graphical) session available
 read -n 1 -s -r -p "Press any key to continue"
 
 
-echo "${YELLOW}[~] Install Bettercap2...${RESET}"
-apt-get -y remove bettercap
-rm `which bettercap`
+echo "${YELLOW}[~] Install/Update Bettercap2...${RESET}"
+apt-get -y remove bettercap || true
+command -v bettercap >/dev/null 2>&1 && rm -f "$(command -v bettercap)"
 apt-get install -y bettercap
-`which bettercap` -version
+bettercap -version || true
+read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install crEAP...${RESET}"
-cd /usr/share
-git clone https://github.com/Shellntel/scripts.git creap
+if [ -d /usr/share/creap ]; then
+	cd /usr/share/creap && git pull
+else
+	cd /usr/share && git clone https://github.com/Shellntel/scripts.git creap
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install EAPHammer...${RESET}"
-cd /usr/share
-git clone https://github.com/s0lst1c3/eaphammer.git
-cd eaphammer
-./kali-setup
-python3 -m pip install flask_cors
-python3 -m pip install flask_socketio
-python3 -m pip install --upgrade gevent
+if [ -d /usr/share/eaphammer ]; then
+	cd /usr/share/eaphammer && git pull
+else
+	cd /usr/share && git clone https://github.com/s0lst1c3/eaphammer.git
+fi
+cd /usr/share/eaphammer
+./kali-setup || true
+python3 -m pip install flask_cors flask_socketio gevent --break-system-packages 2>/dev/null || python3 -m pip install flask_cors flask_socketio gevent
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install Airgeddon...${RESET}"
-cd /usr/share
-git clone https://github.com/v1s1t0r1sh3r3/airgeddon.git
+if [ -d /usr/share/airgeddon ]; then
+	cd /usr/share/airgeddon && git pull
+else
+	cd /usr/share && git clone https://github.com/v1s1t0r1sh3r3/airgeddon.git
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
-#echo "${YELLOW}[~] Install Hostapd-mana...${RESET}"
-#cd /usr/share
-#git clone https://github.com/sensepost/hostapd-mana
-#cd hostapd-mana
-#make -C hostapd
-
-
 echo "${YELLOW}[~] Install Berate_ap...${RESET}"
-cd /usr/share
-git clone https://github.com/sensepost/berate_ap.git
+if [ -d /usr/share/berate_ap ]; then
+	cd /usr/share/berate_ap && git pull
+else
+	cd /usr/share && git clone https://github.com/sensepost/berate_ap.git
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Install WPA_Sycophant...${RESET}"
-cd /usr/share
-git clone https://github.com/sensepost/wpa_sycophant.git
+if [ -d /usr/share/wpa_sycophant ]; then
+	cd /usr/share/wpa_sycophant && git pull
+else
+	cd /usr/share && git clone https://github.com/sensepost/wpa_sycophant.git
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 updatedb
 
+echo "${YELLOW}[~] Cleaning up package cache...${RESET}"
+apt-get autoremove -y
+apt-get clean
+
 echo "${GREEN}[+] Install script finished. Now Reboot !"
 echo 
-

--- a/scripts/start-guacamole.sh
+++ b/scripts/start-guacamole.sh
@@ -20,13 +20,17 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+# Auto-detect Tomcat version (tomcat9, tomcat10, etc.)
+TOMCAT_SVC=$(systemctl list-unit-files --type=service 2>/dev/null | grep -oE '^tomcat[0-9]*\.service' | head -n1 | sed 's/\.service//')
+[ -z "$TOMCAT_SVC" ] && TOMCAT_SVC="tomcat9"
+
 systemctl start guacd
-systemctl start tomcat9
+systemctl start ${TOMCAT_SVC}
 systemctl start mysql
 
 echo "${GREEN}[+] Guacamole started. Access via http://<ip>:8080/guacamole/${RESET}"
 echo
 
 #systemctl status guacd
-#systemctl status tomcat9
+#systemctl status ${TOMCAT_SVC}
 #systemctl status mysql

--- a/scripts/stop-ap-admin.sh
+++ b/scripts/stop-ap-admin.sh
@@ -19,9 +19,8 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-systemctl stop dnsmasq
-systemctl stop hostapd
+systemctl stop dnsmasq || true
+systemctl stop hostapd || true
 
 echo "${GREEN}[+] AP Stopped${RESET}"
 echo
-

--- a/scripts/stop-guacamole.sh
+++ b/scripts/stop-guacamole.sh
@@ -19,13 +19,17 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+# Auto-detect Tomcat version (tomcat9, tomcat10, etc.)
+TOMCAT_SVC=$(systemctl list-unit-files --type=service 2>/dev/null | grep -oE '^tomcat[0-9]*\.service' | head -n1 | sed 's/\.service//')
+[ -z "$TOMCAT_SVC" ] && TOMCAT_SVC="tomcat9"
+
 systemctl stop guacd
-systemctl stop tomcat9
+systemctl stop ${TOMCAT_SVC}
 systemctl stop mysql
 
 echo "${GREEN}[+] Guacamole stopped${RESET}"
 echo
 
 #systemctl status guacd
-#systemctl status tomcat9
+#systemctl status ${TOMCAT_SVC}
 #systemctl status mysql

--- a/scripts/update-system.sh
+++ b/scripts/update-system.sh
@@ -34,49 +34,86 @@ read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Update Wifipumpkin3...${RESET}"
-cd /usr/share/wifipumpkin3
-git pull
-python3 setup.py install
-wifipumpkin3 --version
+if [ -d /usr/share/wifipumpkin3 ]; then
+	cd /usr/share/wifipumpkin3
+	git pull
+	python3 -m pip install . --break-system-packages 2>/dev/null || python3 -m pip install .
+	wifipumpkin3 --version || true
+else
+	echo "${RED}[!] Wifipumpkin3 not found in /usr/share/wifipumpkin3${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Update Wifiphisher...${RESET}"
-cd /usr/share/wifiphisher
-git pull
-python3 setup.py install
+if [ -d /usr/share/wifiphisher ]; then
+	cd /usr/share/wifiphisher
+	git pull
+	python3 -m pip install . --break-system-packages 2>/dev/null || python3 -m pip install .
+else
+	echo "${RED}[!] Wifiphisher not found in /usr/share/wifiphisher${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Update Fluxion...${RESET}"
-cd /usr/share/fluxion
-git pull
+if [ -d /usr/share/fluxion ]; then
+	cd /usr/share/fluxion
+	git pull
+else
+	echo "${RED}[!] Fluxion not found in /usr/share/fluxion${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Update EAPHammer...${RESET}"
-cd /usr/share/eaphammer
-git pull
-# Setup takes lots of time, do it manually
-#./kali-setup
-echo "${YELLOW}[~] Setup of updated files should be run manually (/usr/share/kali-setup.sh). Takes lots of time !${RESET}"
+if [ -d /usr/share/eaphammer ]; then
+	cd /usr/share/eaphammer
+	git pull
+	# Setup takes lots of time, do it manually
+	#./kali-setup
+	echo "${YELLOW}[~] Setup of updated files should be run manually (/usr/share/eaphammer/kali-setup). Takes lots of time !${RESET}"
+else
+	echo "${RED}[!] EAPHammer not found in /usr/share/eaphammer${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Update Airgeddon...${RESET}"
-cd /usr/share/airgeddon
-git pull
+if [ -d /usr/share/airgeddon ]; then
+	cd /usr/share/airgeddon
+	git pull
+else
+	echo "${RED}[!] Airgeddon not found in /usr/share/airgeddon${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
 echo "${YELLOW}[~] Update Berate_ap...${RESET}"
-cd /usr/share/berate_ap
-git pull
+if [ -d /usr/share/berate_ap ]; then
+	cd /usr/share/berate_ap
+	git pull
+else
+	echo "${RED}[!] Berate_ap not found in /usr/share/berate_ap${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
 
-echo "${YELLOW}[~] Install WPA_Sycophant...${RESET}"
-cd /usr/share/wpa_sycophant
-git pull
+echo "${YELLOW}[~] Update WPA_Sycophant...${RESET}"
+if [ -d /usr/share/wpa_sycophant ]; then
+	cd /usr/share/wpa_sycophant
+	git pull
+else
+	echo "${RED}[!] WPA_Sycophant not found in /usr/share/wpa_sycophant${RESET}"
+fi
 read -n 1 -s -r -p "Press any key to continue"
 
+
+echo "${YELLOW}[~] Update locate database...${RESET}"
+updatedb
+
+echo "${YELLOW}[~] Cleaning up package cache...${RESET}"
+apt-get autoremove -y
+apt-get clean
+
+echo "${GREEN}[+] Update finished.${RESET}"


### PR DESCRIPTION
- Fix inverted sources.list logic (was overwriting file instead of appending)
- Remove obsolete Python 2 dependencies (get-pip.py, scapy-com)
- Replace invalid 'dhcpd' package with 'isc-dhcp-server'
- Add automatic Tomcat version detection (9/10) in guacamole scripts
- Configure hostapd DAEMON_CONF and disable isc-dhcp-server to avoid port 67 conflict
- Fix hostapd backup path and add timestamped config backups for idempotency
- Add VNC password validation before starting service
- Add apt cleanup (autoremove + clean) to install and update scripts
- Update README: add RPi 4/5 support, troubleshooting section, security notes
- Fix vncserver.service: remove double Type=, add explicit :1 display